### PR TITLE
Add zero-interest handling and fix amortization tests

### DIFF
--- a/src/LoanAmortization.php
+++ b/src/LoanAmortization.php
@@ -85,7 +85,11 @@ class LoanAmortization
 
     private function calculate(): array
     {
-        $this->term_pay = $this->loan_amount * ($this->interest / (1 - pow((1 + $this->interest), -$this->term_months)));
+        if ($this->interest == 0.0) {
+            $this->term_pay = $this->loan_amount / $this->term_months;
+        } else {
+            $this->term_pay = $this->loan_amount * ($this->interest / (1 - pow((1 + $this->interest), -$this->term_months)));
+        }
         $interest = $this->loan_amount * $this->interest;
 
         $principal = $this->term_pay - $interest;

--- a/tests/LoanAmortizationTest.php
+++ b/tests/LoanAmortizationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Apxcde\LoanAmortization\LoanAmortization;
+
+it('calculates monthly payment correctly', function () {
+    $loanData = [
+        'loan_amount' => 100000.0,
+        'term_years' => 1,
+        'interest' => 12,
+        'term_months' => 12,
+        'starting_date' => new DateTime('2023-01-01'),
+        'remaining_months' => 12,
+    ];
+
+    $loan = new LoanAmortization($loanData);
+    $summary = $loan->getResults()['summary'];
+
+    expect(round($summary['monthly_repayment'], 2))->toBe(8884.88);
+});
+
+it('provides correct summary totals', function () {
+    $loanData = [
+        'loan_amount' => 100000.0,
+        'term_years' => 1,
+        'interest' => 12,
+        'term_months' => 12,
+        'starting_date' => new DateTime('2023-01-01'),
+        'remaining_months' => 12,
+    ];
+
+    $loan = new LoanAmortization($loanData);
+    $summary = $loan->getResults()['summary'];
+
+    $expectedTotalPay = $summary['monthly_repayment'] * 12;
+    $expectedTotalInterest = $expectedTotalPay - 100000.0;
+
+    expect($summary['total_pay'])->toEqualWithDelta($expectedTotalPay, 0.01);
+    expect($summary['total_interest'])->toEqualWithDelta($expectedTotalInterest, 0.01);
+});
+
+it('handles zero interest', function () {
+    $loanData = [
+        'loan_amount' => 12000.0,
+        'term_years' => 1,
+        'interest' => 0,
+        'term_months' => 12,
+        'starting_date' => new DateTime('2023-01-01'),
+        'remaining_months' => 12,
+    ];
+
+    $loan = new LoanAmortization($loanData);
+    $summary = $loan->getResults()['summary'];
+
+    expect(round($summary['monthly_repayment'], 2))->toBe(1000.00);
+});
+
+it('generates schedule with paid months when partial payments were made', function () {
+    $loanData = [
+        'loan_amount' => 10000.0,
+        'term_years' => 1,
+        'interest' => 12,
+        'term_months' => 12,
+        'starting_date' => new DateTime('2023-01-01'),
+        'remaining_months' => 6,
+    ];
+
+
+    $loan = new LoanAmortization($loanData);
+    $schedule = $loan->getResults()['schedule'];
+
+    expect(count($schedule))->toBe(12);
+
+    $paid = array_filter($schedule, fn($row) => $row[0] === 'paid');
+    $notPaid = array_filter($schedule, fn($row) => $row[0] === 'not_paid');
+
+    expect(count($paid))->toBe(6)
+        ->and(count($notPaid))->toBe(6);
+});
+

--- a/tests/LoanAmortizationTest.php
+++ b/tests/LoanAmortizationTest.php
@@ -72,10 +72,9 @@ it('generates schedule with paid months when partial payments were made', functi
 
     expect(count($schedule))->toBe(12);
 
-    $paid = array_filter($schedule, fn($row) => $row[0] === 'paid');
-    $notPaid = array_filter($schedule, fn($row) => $row[0] === 'not_paid');
+    $paid = array_filter($schedule, fn ($row) => $row[0] === 'paid');
+    $notPaid = array_filter($schedule, fn ($row) => $row[0] === 'not_paid');
 
     expect(count($paid))->toBe(6)
         ->and(count($notPaid))->toBe(6);
 });
-


### PR DESCRIPTION
## Summary
- handle zero-interest scenarios gracefully in `LoanAmortization`
- update amortization tests to use initial results
- verify partial payment schedule generation

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6857b6126544832d8f1ed449c93322c5