### PR TITLE
Add strict types and refine property declarations

### DIFF
--- a/src/LoanAmortization.php
+++ b/src/LoanAmortization.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Apxcde\LoanAmortization;
 
@@ -7,10 +8,10 @@ class LoanAmortization
     private float $loan_amount;
     private int|float $interest;
     private int $term_months;
-    private mixed $balance;
-    private mixed $term_pay;
-    private mixed $date;
-    private mixed $remaining_months;
+    private float $balance;
+    private float $term_pay;
+    private \DateTimeInterface $date;
+    private int $remaining_months;
     public array $results;
 
     public function __construct(array $data)

--- a/src/LoanAmortization.php
+++ b/src/LoanAmortization.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Apxcde\LoanAmortization;


### PR DESCRIPTION
## Summary
- enable strict types
- use explicit property types instead of mixed
- accept `DateTimeInterface` for the date property

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6857d2eb3470832daf083e61c751e6d8